### PR TITLE
Add task to ensure min size of PIXI_CACHE_DIR

### DIFF
--- a/template/pixi.toml.jinja
+++ b/template/pixi.toml.jinja
@@ -12,9 +12,10 @@ platforms = ["linux-64"]
 linux="4.18"
 
 [tasks]
+cache_status = { cmd = 'pixi run python ./source/check_pixi_cache_dir.py' }
 source_status = { cmd = 'echo "Found $(git status --porcelain source | wc -l) untracked changes in ./source." && exit $(git status --porcelain source | wc -m)'}
 log_commit = {cmd = 'echo "[$(date -Iseconds)][Executing] $TASK [Git-Commit] $(git rev-parse --verify HEAD)" >> $WD/githash.log', env = {TASK = ""}}
-build_config = { cmd = "mkdir -p $WD ; TASK=BUILD_CONFIG pixi run log_commit ; cd $WD ; echo 'Implementation Missing.'", env = { WD = "runs/example"}, depends_on=["source_status"]}
+build_config = { cmd = "mkdir -p $WD ; TASK=BUILD_CONFIG pixi run log_commit ; cd $WD ; echo 'Implementation Missing.'", env = { WD = "runs/example"}, depends_on=["cache_status", "source_status"]}
 
 [dependencies]
 python = "3.12"

--- a/template/source/check_pixi_cache_dir.py
+++ b/template/source/check_pixi_cache_dir.py
@@ -1,0 +1,17 @@
+import json
+import shutil
+import subprocess
+
+info = subprocess.run(["pixi", "info", "--json"], stdout=subprocess.PIPE)
+cache_dir = json.loads(info.stdout)["cache_dir"]
+
+GB = 1024 * 1024 * 1024
+if shutil.disk_usage(cache_dir).free < 2 * GB:
+    message = f"""
+    Low disk space in cache directory.
+
+    The PIXI_CACHE_DIR is set to:
+    {cache_dir}
+
+    Did you initialize your session correctly ('source ./init.sh') ?"""
+    raise RuntimeError(message)


### PR DESCRIPTION
Closes #20.

I ended up using a small Python script to parse the output of `pixi info --json`. Not sure if it's worth adding this to the template, but I'm putting here for the record as I used it in one project, and it's certainly useful on Windows (when working with a home directory that's on the network and has low quota).
